### PR TITLE
chore(docker): add Focker mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 | 12 | Node.js  | NPM - Yarnpkg (Global) |
 | 13 | Docker   | Docker Hub - Runflare (Iran) |
 | 14 | Docker   | Docker Hub - ArvanCloud (Iran) |
+| 14 | Docker   | Docker Hub - Focker (Iran) |
 | 15 | Docker   | Docker Hub - Hamravesh (Iran) |
 | 16 | Docker   | Docker Hub - IranServer (Iran) |
 | 17 | Docker   | Docker Hub - USTC (China) |

--- a/script.sh
+++ b/script.sh
@@ -64,6 +64,7 @@ MIRRORS=(
 
     # Docker
     "Docker|Docker Hub - Runflare (Iran)|https://mirror-docker.runflare.com"
+    "Docker|Docker Hub - Focker (Iran)|https://focker.ir"
     "Docker|Docker Hub - ArvanCloud (Iran)|https://docker.arvancloud.ir/"
     "Docker|Docker Hub - Hamravesh (Iran)|https://hub.hamdocker.ir/"
     "Docker|Docker Hub - IranServer (Iran)|https://docker.iranserver.com/"


### PR DESCRIPTION
Added Focker mirror (https://focker.ir/) to Docker registry configuration and updated README with usage instructions.
This improves image pull speed and reliability for developers in supported regions.